### PR TITLE
Revert "Dockerfile: install Google's repo tool"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,14 +41,6 @@ RUN apt-get install -qqy --no-install-recommends \
 RUN rm -f /etc/ssl/certs/java/cacerts; \
     /var/lib/dpkg/info/ca-certificates-java.postinst configure
 
-# Install Google's repo tool version 1.23 (https://source.android.com/setup/build/downloading#installing-repo)
-RUN curl -s https://storage.googleapis.com/git-repo-downloads/repo > /tmp/repo && \
-    echo "e147f0392686c40cfd7d5e6f332c6ee74c4eab4d24e2694b3b0a0c037bf51dc5  /tmp/repo" > /tmp/repo.sha265 && \
-    sha256sum -c /tmp/repo.sha265 && \
-    rm /tmp/repo.sha265 && \
-    mv /tmp/repo /usr/bin/repo && \
-    chmod a+x /usr/bin/repo
-
 # download and unzip sdk
 RUN curl -s https://dl.google.com/android/repository/sdk-tools-linux-${SDK_TOOLS_VERSION}.zip > /tools.zip && \
     unzip /tools.zip -d /sdk && \


### PR DESCRIPTION
I added Google's repo tool, because we used this docker image to build a
multi service interconnected framework for android with multiple
services, apps and repositories. This is not common for standard Android
App development. More a case of AOSP system programming.

Since our team has refactored your CI and repository structure, we
don't need `repo` in this docker image anymore.

So I think it's safe to remove `repo` from this image again, because
nobody else who does normal App development needs `repo` in this image.

This reverts commit 3d905dfe6c4233d8c41b04ab8067beb80b911b2f.