### PR TITLE
Install Java linter checkstyle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ENV LANG en_US.UTF-8
 RUN apt-get install -qqy --no-install-recommends \
     apt-utils \
     openjdk-8-jdk \
+    checkstyle \
     libc6-i386 \
     lib32stdc++6 \
     lib32gcc1 \


### PR DESCRIPTION
The Java linter checkstyle[1] is useful to verify code style and check
for simple coding errors. Adding it to the docker image allows to use it
in gitlab CI pipelines apart from integrating it with gradle.

[1]: http://checkstyle.sourceforge.net/