### PR TITLE
Install the ninja build tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get install -qqy --no-install-recommends \
     cmake \
     lldb \
     git \
+    ninja-build \
     build-essential \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Recently the Android SDK has updated the cmake version from 3.6 to 3.10.
Now cmake defaults to using Unix Makefiles instead Ninja build files.
Since there is no easy way to switch back to Unix Makefiles with gradle
options in our android app build scripts and the ninja build tool
usually builds faster than make, just install the ninja build tool in
the docker image.

This fixes our current CI pipline failures for our cmake based native
Android apps.