### PR TITLE
Update December 2020

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,23 @@
 #
 # inovex GitLab CI: Android v1.0
-# Build Tools: v28.0.3
-# Platforms: 27, 28
+# Build Tools: v29.0.3
+# Platforms: 29, 30
+# NDK: r21d
 # https://hub.docker.com/r/inovex/gitlab-ci-android/
 # https://www.inovex.de
 #
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL maintainer inovex GmbH
 
-ENV SDK_TOOLS_VERSION "4333796"
-ENV NDK_VERSION r18b
+ENV CMD_LINE_TOOLS_VERSION "6858069"
+ENV NDK_VERSION r21d
 
-ENV ANDROID_HOME "/sdk"
+ENV ANDROID_SDK_ROOT "/sdk"
 ENV ANDROID_NDK_HOME "/ndk"
-ENV PATH "$PATH:${ANDROID_HOME}/tools"
+ENV PATH "$PATH:${ANDROID_SDK_ROOT}/bin"
+
+ENV DEBIAN_FRONTEND=noninteractive 
 
 RUN apt-get -qq update && apt-get install -y locales \
 	&& localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
@@ -31,7 +34,7 @@ RUN apt-get install -qqy --no-install-recommends \
     libc6-i386 \
     lib32stdc++6 \
     lib32gcc1 \
-    lib32ncurses5 \
+    lib32ncurses6 \
     lib32z1 \
     unzip \
     curl \
@@ -47,15 +50,12 @@ RUN rm -f /etc/ssl/certs/java/cacerts; \
     /var/lib/dpkg/info/ca-certificates-java.postinst configure
 
 # Install Google's repo tool version 1.23 (https://source.android.com/setup/build/downloading#installing-repo)
-RUN curl -s https://storage.googleapis.com/git-repo-downloads/repo > /tmp/repo && \
-    echo "e147f0392686c40cfd7d5e6f332c6ee74c4eab4d24e2694b3b0a0c037bf51dc5  /tmp/repo" > /tmp/repo.sha265 && \
-    sha256sum -c /tmp/repo.sha265 && \
-    rm /tmp/repo.sha265 && \
-    mv /tmp/repo /usr/bin/repo && \
-    chmod a+x /usr/bin/repo
+RUN curl -o /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo \
+ && echo "d73f3885d717c1dc89eba0563433cec787486a0089b9b04b4e8c56e7c07c7610  /usr/local/bin/repo" | sha256sum --strict -c - \
+ && chmod a+x /usr/local/bin/repo
 
 # download and unzip sdk
-RUN curl -s https://dl.google.com/android/repository/sdk-tools-linux-${SDK_TOOLS_VERSION}.zip > /tools.zip && \
+RUN curl -s https://dl.google.com/android/repository/commandlinetools-linux-${CMD_LINE_TOOLS_VERSION}_latest.zip > /tools.zip && \
     unzip /tools.zip -d /sdk && \
     rm -v /tools.zip
 
@@ -63,18 +63,18 @@ RUN curl -s https://dl.google.com/android/repository/sdk-tools-linux-${SDK_TOOLS
 ADD pkg.txt /sdk
 RUN mkdir -p /root/.android && touch /root/.android/repositories.cfg
 
-RUN mkdir -p $ANDROID_HOME/licenses/ \
-  && echo "8933bad161af4178b1185d1a37fbf41ea5269c55\nd56f5187479451eabf01fb78af6dfcb131a6481e\n24333f8a63b6825ea9c5514f83c2829b004d1fee" > $ANDROID_HOME/licenses/android-sdk-license \
-  && echo "84831b9409646a918e30573bab4c9c91346d8abd\n504667f4c0de7af1a06de9f4b1727b84351f2910" > $ANDROID_HOME/licenses/android-sdk-preview-license
+RUN mkdir -p $ANDROID_SDK_ROOT/licenses/ \
+  && echo "8933bad161af4178b1185d1a37fbf41ea5269c55\nd56f5187479451eabf01fb78af6dfcb131a6481e\n24333f8a63b6825ea9c5514f83c2829b004d1fee" > $ANDROID_SDK_ROOT/licenses/android-sdk-license \
+  && echo "84831b9409646a918e30573bab4c9c91346d8abd\n504667f4c0de7af1a06de9f4b1727b84351f2910" > $ANDROID_SDK_ROOT/licenses/android-sdk-preview-license
 
 # Accept licenses
-RUN yes | ${ANDROID_HOME}/tools/bin/sdkmanager --licenses
+RUN yes | ${ANDROID_SDK_ROOT}/cmdline-tools/bin/sdkmanager --licenses --sdk_root=${ANDROID_SDK_ROOT}
 
 # Update
-RUN ${ANDROID_HOME}/tools/bin/sdkmanager --update 
+RUN ${ANDROID_SDK_ROOT}/cmdline-tools/bin/sdkmanager --update --sdk_root=${ANDROID_SDK_ROOT}
 
 RUN while read -r pkg; do PKGS="${PKGS}${pkg} "; done < /sdk/pkg.txt && \
-    ${ANDROID_HOME}/tools/bin/sdkmanager ${PKGS}
+    ${ANDROID_SDK_ROOT}/cmdline-tools/bin/sdkmanager ${PKGS} --sdk_root=${ANDROID_SDK_ROOT}
 
 RUN mkdir /tmp/android-ndk && \
     cd /tmp/android-ndk && \

--- a/pkg.txt
+++ b/pkg.txt
@@ -1,7 +1,6 @@
-build-tools;28.0.3
-platforms;android-28
-platforms;android-27
-platform-tools
+build-tools;30.0.2
+platforms;android-30
+platforms;android-29
 extras;android;m2repository
 extras;google;google_play_services
 extras;google;m2repository


### PR DESCRIPTION
- Include Platform 29 and 30
- Use latest Build Tools
- Use latest NDK
- Use Ubuntu 20.04
- Move from SDK Tools to Command line tools