### PR TITLE
Dockerfiler: Fix missing 'apt-get update'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV LANG en_US.UTF-8
 # install necessary packages
 # prevent installation of openjdk-11-jre-headless with a trailing minus,
 # as openjdk-8-jdk can provide all requirements and will be used anyway
-RUN apt-get install -qqy --no-install-recommends \
+RUN apt-get update && apt-get install -qqy --no-install-recommends \
     apt-utils \
     openjdk-8-jdk \
     openjdk-11-jdk \


### PR DESCRIPTION
Add an 'apt-get update' before  the package installation. Otherwise the package cache maybe stall and you see errors like

    E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/t/tiff/libtiff5_4.1.0+git191117-2ubuntu0.20.04.9_amd64.deb  404  Not Found [IP: 91.189.91.81 80]
    E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/c/curl/libcurl4_7.68.0-1ubuntu2.19_amd64.deb  404  Not Found [IP: 91.189.91.81 80]
    E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/c/curl/curl_7.68.0-1ubuntu2.19_amd64.deb  404  Not Found [IP: 91.189.91.81 80]
    E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/c/curl/libcurl3-gnutls_7.68.0-1ubuntu2.19_amd64.deb  404  Not Found [IP: 91.189.91.81 80]
    E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?

Adding the extra update is a recommend practice. See

    https://docs.docker.com/develop/develop-images/guidelines/
    https://techoverflow.net/2021/01/13/how-to-use-apt-install-correctly-in-your-dockerfile/