### PR TITLE
fix broken 'repo' tool and update repo checksum

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get install -qqy --no-install-recommends \
     cmake \
     lldb \
     git \
+    python-is-python3 \
     ninja-build \
     build-essential \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -46,7 +47,7 @@ RUN rm -f /etc/ssl/certs/java/cacerts; \
 
 # Install Google's repo tool version 1.23 (https://source.android.com/setup/build/downloading#installing-repo)
 RUN curl -o /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo \
- && echo "974992a8bc1c787979f3eb7702a803b051deddc3cd75726c4de52e09e93b798d /usr/local/bin/repo" | sha256sum --strict -c - \
+ && echo "18ec0f6e1ac3c12293a4521a5c2224d96e4dd5ee49662cc837c2dd854ef824e5 /usr/local/bin/repo" | sha256sum --strict -c - \
  && chmod a+x /usr/local/bin/repo
 
 # download and unzip latest command line tools


### PR DESCRIPTION
The repo tools needs python to be installed. Otherwise you see the error

    root@xxxx:/# repo
    /usr/bin/env: ‘python’: No such file or directory

Install the package 'python-is-python3' so the program name 'python' is installed and points to python3.

Also update the checksum of the repo tool. Otherwise the container cannot be built.